### PR TITLE
Use constant instead of literal

### DIFF
--- a/Chapter11/Ch11_06/Ch11_06.cpp
+++ b/Chapter11/Ch11_06/Ch11_06.cpp
@@ -20,7 +20,7 @@ void ShiftA(void)
     const size_t n = 4;
 
     uint32_t a = 0xC1234561;
-    uint32_t x[4];
+    uint32_t x[n];
     ShiftA_(x, a);
     PrintResult("ShiftA_", x, a, n);
 }
@@ -30,7 +30,7 @@ void ShiftB(void)
     const size_t n = 4;
 
     uint32_t a = 0xC1234561;
-    uint32_t x[4];
+    uint32_t x[n];
     uint32_t count = 8;
     ShiftB_(x, a, count);
     PrintResult("ShiftB_", x, a, n, (int)count);

--- a/Chapter12/Ch12_04/Ch12_04_.s
+++ b/Chapter12/Ch12_04/Ch12_04_.s
@@ -28,12 +28,12 @@ SumSquaresB_:
             add x1,x0,1                         // x1 = n + 1
             mul x2,x0,x1                        // x2 = n * (n + 1)
 
-            lsl x3,x0,1                         // r3 = 2 * n
-            add x3,x3,1                         // r3 = 2 * n + 1
-            mul x3,x3,x2                        // r3 = dividend
+            lsl x3,x0,1                         // x3 = 2 * n
+            add x3,x3,1                         // x3 = 2 * n + 1
+            mul x3,x3,x2                        // x3 = dividend
 
-            mov x1,6                            // r1 = divisor
-            sdiv x0,x3,x1                       // r0 = final sum
+            mov x1,6                            // x1 = divisor
+            sdiv x0,x3,x1                       // x0 = final sum
             ret
 
 // extern "C" void SumSquares_(int64_t n, int64_t* sum_a, int64_t* sum_b);

--- a/Chapter12/Ch12_05/Ch12_05_.s
+++ b/Chapter12/Ch12_05/Ch12_05_.s
@@ -32,7 +32,7 @@ CalcArraySumB_:
 
             mov w3,0                            // i = 0
 
-LoopB:      ldr x4,[x0,w3,uxtw 3]               // r5 = x[i]
+LoopB:      ldr x4,[x0,w3,uxtw 3]               // x4 = x[i]
             add x2,x2,x4                        // sum += x[i]
 
             add w3,w3,1                         // i += 1


### PR DESCRIPTION
This is admittedly nit-picky, but `n` is the size of the array so it should be used instead of `4`. This is consistent with Ch11_07.cpp which does use the `n` constant.